### PR TITLE
adding n_clicks = 0 to the login button

### DIFF
--- a/pages/auth_pages/login.py
+++ b/pages/auth_pages/login.py
@@ -48,7 +48,7 @@ def layout():
                         dbc.FormText('Password'),
                         
                         html.Br(),
-                        dbc.Button('Submit',color='primary',id='login-button'),
+                        dbc.Button('Submit',color='primary',id='login-button', n_clicks=0),
                         #dbc.FormText(id='output-state')
                         
                         html.Br(),


### PR DESCRIPTION
adding n_clicks = 0 to the login button to remove the callback error
TypeError: '>' not supported between instances of 'NoneType' and 'int'